### PR TITLE
avoid crash on starting newt window

### DIFF
--- a/src/newt/native/MacNewtNSWindow.m
+++ b/src/newt/native/MacNewtNSWindow.m
@@ -848,7 +848,9 @@ NS_ENDHANDLER
         insetsChangedID && sizeScreenPosInsetsChangedID &&
         screenPositionChangedID && focusChangedID && windowDestroyNotifyID && requestFocusID && windowRepaintID)
     {
-        CKCH_CreateDictionaries();
+        dispatch_async(dispatch_get_main_queue(), ^(){
+            CKCH_CreateDictionaries();
+        });
         return YES;
     }
     return NO;


### PR DESCRIPTION
crashes on starting newt window.
`BUG IN CLIENT OF LIBDISPATCH: Assertion failed: Block was expected to execute on queue [com.apple.main-thread]`
